### PR TITLE
Preparation for metaproteomics annotate through annotation file

### DIFF
--- a/MqApi/Param/AnnotationFilesParam.cs
+++ b/MqApi/Param/AnnotationFilesParam.cs
@@ -1,0 +1,59 @@
+using MqApi.Num;
+using MqApi.Util;
+namespace MqApi.Param{
+	public class AnnotationFilesParam : Parameter<string[][]>{
+		/// <summary>
+		/// for xml serialization only
+		/// </summary>
+		public AnnotationFilesParam() : this(""){
+		}
+		public AnnotationFilesParam(string name) : this(name, new string[0][]){
+		}
+		public AnnotationFilesParam(string name, string[][] value) : base(name){
+			Value = value;
+			Default = new string[Value.Length][];
+			for (int i = 0; i < Value.Length; i++){
+				Default[i] = new string[Value[i].Length];
+				for (int j = 0; j < Value[i].Length; j++){
+					Default[i][j] = Value[i][j];
+				}
+			}
+		}
+		protected AnnotationFilesParam(string name, string help, string url, bool visible, string[][] value,
+			string[][] default1) : base(name, help, url, visible, value, default1){
+		}
+		public override void Read(BinaryReader reader){
+			base.Read(reader);
+			Value = FileUtils.Read2DStringArray(reader);
+			Default = FileUtils.Read2DStringArray(reader);
+		}
+		public override void Write(BinaryWriter writer){
+			base.Write(writer);
+			FileUtils.Write(Value, writer);
+			FileUtils.Write(Default, writer);
+		}
+		public override string StringValue{
+			get => StringUtils.Concat(";", ",", Value);
+			set{
+				if (value.Trim().Length == 0){
+					Value = new string[0][];
+					return;
+				}
+				string[] x = value.Split(';');
+				Value = new string[x.Length][];
+				for (int i = 0; i < x.Length; i++){
+					Value[i] = x[i].Split(',');
+				}
+			}
+		}
+		public override bool IsModified => !ArrayUtils.EqualArraysOfArrays(Default, Value);
+		public override void Clear(){
+			Value = new string[0][];
+		}
+		public override float Height => 200f;
+		public override ParamType Type => ParamType.Server;
+		public override object Clone(){
+			return new AnnotationFilesParam(Name, Help, Url, Visible, Value, Default);
+		}
+	}
+}

--- a/MqUtil/Annotation/AnnotationFileInfo.cs
+++ b/MqUtil/Annotation/AnnotationFileInfo.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections.Generic;
+using MqUtil.Util;
+namespace MqUtil.Annotation{
+	[Serializable]
+	public class AnnotationFileInfo : IComparable<AnnotationFileInfo>{
+		public const string DefaultValueSeparators = ";,";
+
+		public readonly List<InputParameter> vals = new List<InputParameter>{
+			new InputParameter<string>("filePath", "filePath"),
+			new InputParameter<string>("identifierColumn", "identifierColumn"),
+			new InputParameter<string>("taxonomyColumn", "taxonomyColumn"),
+			new InputParameter<string>("koColumn", "koColumn"),
+			new InputParameter<string>("cogColumn", "cogColumn"),
+			new InputParameter<string>("ecColumn", "ecColumn"),
+			new InputParameter<string>("valueSeparators", "valueSeparators", DefaultValueSeparators)
+		};
+
+		public readonly Dictionary<string, InputParameter> map;
+		public string filePath;
+		public string identifierColumn;
+		public string taxonomyColumn;
+		public string koColumn;
+		public string cogColumn;
+		public string ecColumn;
+		public string valueSeparators;
+
+		public AnnotationFileInfo() : this("", "", "", "", "", "", DefaultValueSeparators){ }
+
+		public AnnotationFileInfo(string filePath) : this(filePath, "", "", "", "", "", DefaultValueSeparators){ }
+
+		public AnnotationFileInfo(string filePath, string identifierColumn, string taxonomyColumn, string koColumn,
+			string cogColumn, string ecColumn, string valueSeparators){
+			map = new Dictionary<string, InputParameter>();
+			foreach (InputParameter val in vals){
+				map.Add(val.Name, val);
+			}
+			this.filePath = filePath;
+			this.identifierColumn = identifierColumn;
+			this.taxonomyColumn = taxonomyColumn;
+			this.koColumn = koColumn;
+			this.cogColumn = cogColumn;
+			this.ecColumn = ecColumn;
+			this.valueSeparators = string.IsNullOrEmpty(valueSeparators) ? DefaultValueSeparators : valueSeparators;
+		}
+
+		public AnnotationFileInfo(string[] s) : this(){
+			filePath = s[0];
+			identifierColumn = s.Length > 1 ? s[1] : "";
+			taxonomyColumn = s.Length > 2 ? s[2] : "";
+			koColumn = s.Length > 3 ? s[3] : "";
+			cogColumn = s.Length > 4 ? s[4] : "";
+			ecColumn = s.Length > 5 ? s[5] : "";
+			string sep = s.Length > 6 ? s[6] : "";
+			valueSeparators = string.IsNullOrEmpty(sep) ? DefaultValueSeparators : sep;
+		}
+
+		public string[] ToStringArray(){
+			return new[]{
+				filePath, identifierColumn, taxonomyColumn, koColumn, cogColumn, ecColumn, valueSeparators
+			};
+		}
+
+		public static string[] GetFilePath(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].filePath;
+			}
+			return result;
+		}
+
+		public static string[] GetIdentifierColumn(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].identifierColumn;
+			}
+			return result;
+		}
+
+		public static string[] GetTaxonomyColumn(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].taxonomyColumn;
+			}
+			return result;
+		}
+
+		public static string[] GetKoColumn(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].koColumn;
+			}
+			return result;
+		}
+
+		public static string[] GetCogColumn(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].cogColumn;
+			}
+			return result;
+		}
+
+		public static string[] GetEcColumn(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].ecColumn;
+			}
+			return result;
+		}
+
+		public static string[] GetValueSeparators(AnnotationFileInfo[] files){
+			string[] result = new string[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].valueSeparators;
+			}
+			return result;
+		}
+
+		public static string[][] AdaptFiles(AnnotationFileInfo[] files){
+			string[][] result = new string[files.Length][];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = files[i].ToStringArray();
+			}
+			return result;
+		}
+
+		public static AnnotationFileInfo[] AdaptFiles(string[][] files){
+			AnnotationFileInfo[] result = new AnnotationFileInfo[files.Length];
+			for (int i = 0; i < result.Length; i++){
+				result[i] = new AnnotationFileInfo(files[i]);
+			}
+			return result;
+		}
+
+		public int CompareTo(AnnotationFileInfo other){
+			return string.Compare(filePath, other.filePath, StringComparison.InvariantCulture);
+		}
+
+		public override string ToString(){
+			return filePath;
+		}
+	}
+}

--- a/MqUtil/Annotation/AnnotationFileLoader.cs
+++ b/MqUtil/Annotation/AnnotationFileLoader.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+namespace MqUtil.Annotation{
+	public sealed class LoadedProteinAnnotation{
+		public int Taxid;
+		public string[] Ko = Array.Empty<string>();
+		public string[] Cog = Array.Empty<string>();
+		public string[] Ec = Array.Empty<string>();
+	}
+
+	public sealed class AnnotationFilePreview{
+		public string[] Headers = Array.Empty<string>();
+		public List<string[]> Rows = new List<string[]>();
+	}
+
+	public static class AnnotationFileLoader{
+		private const char Bom = '﻿';
+
+		public static AnnotationFilePreview Preview(string path, int nDataRows = 10){
+			AnnotationFilePreview result = new AnnotationFilePreview();
+			using StreamReader r = new StreamReader(path);
+			bool headerRead = false;
+			int rowsRead = 0;
+			string line;
+			bool firstNonEmpty = true;
+			while ((line = r.ReadLine()) != null){
+				if (firstNonEmpty && line.Length > 0 && line[0] == Bom){
+					line = line.Substring(1);
+				}
+				if (string.IsNullOrWhiteSpace(line)){
+					continue;
+				}
+				firstNonEmpty = false;
+				if (!headerRead){
+					string headerLine = line;
+					if (headerLine.StartsWith("#")){
+						headerLine = headerLine.Substring(1);
+					}
+					result.Headers = headerLine.Split('\t');
+					headerRead = true;
+					continue;
+				}
+				if (line.StartsWith("#")){
+					continue;
+				}
+				result.Rows.Add(line.Split('\t'));
+				rowsRead++;
+				if (rowsRead >= nDataRows){
+					break;
+				}
+			}
+			return result;
+		}
+
+		public static Dictionary<string, LoadedProteinAnnotation> Load(AnnotationFileInfo info){
+			Dictionary<string, LoadedProteinAnnotation> result = new Dictionary<string, LoadedProteinAnnotation>();
+			if (string.IsNullOrEmpty(info.filePath) || !File.Exists(info.filePath)){
+				return result;
+			}
+			using StreamReader r = new StreamReader(info.filePath);
+			string[] headers = null;
+			int idIdx = -1;
+			int taxIdx = -1;
+			int koIdx = -1;
+			int cogIdx = -1;
+			int ecIdx = -1;
+			string seps = string.IsNullOrEmpty(info.valueSeparators)
+				? AnnotationFileInfo.DefaultValueSeparators
+				: info.valueSeparators;
+			string line;
+			bool firstNonEmpty = true;
+			while ((line = r.ReadLine()) != null){
+				if (firstNonEmpty && line.Length > 0 && line[0] == Bom){
+					line = line.Substring(1);
+				}
+				if (string.IsNullOrWhiteSpace(line)){
+					continue;
+				}
+				firstNonEmpty = false;
+				if (headers == null){
+					string headerLine = line;
+					if (headerLine.StartsWith("#")){
+						headerLine = headerLine.Substring(1);
+					}
+					headers = headerLine.Split('\t');
+					idIdx = IndexOf(headers, info.identifierColumn);
+					taxIdx = IndexOf(headers, info.taxonomyColumn);
+					koIdx = IndexOf(headers, info.koColumn);
+					cogIdx = IndexOf(headers, info.cogColumn);
+					ecIdx = IndexOf(headers, info.ecColumn);
+					continue;
+				}
+				if (line.StartsWith("#")){
+					continue;
+				}
+				string[] cells = line.Split('\t');
+				if (idIdx < 0 || idIdx >= cells.Length){
+					continue;
+				}
+				string id = cells[idIdx]?.Trim();
+				if (string.IsNullOrEmpty(id) || id == "-"){
+					continue;
+				}
+				LoadedProteinAnnotation a = new LoadedProteinAnnotation();
+				if (taxIdx >= 0 && taxIdx < cells.Length){
+					string taxCell = cells[taxIdx]?.Trim();
+					if (!string.IsNullOrEmpty(taxCell) && taxCell != "-"){
+						int parsed;
+						if (int.TryParse(taxCell, out parsed)){
+							a.Taxid = parsed;
+						}
+					}
+				}
+				a.Ko = ExtractCell(cells, koIdx, seps);
+				a.Cog = ExtractCell(cells, cogIdx, seps);
+				a.Ec = ExtractCell(cells, ecIdx, seps);
+				if (result.ContainsKey(id)){
+					Console.WriteLine("AnnotationFileLoader: duplicate identifier '" + id + "' in " + info.filePath +
+						" — last write wins.");
+				}
+				result[id] = a;
+			}
+			return result;
+		}
+
+		public static string[] SplitMulti(string s, string seps){
+			if (string.IsNullOrEmpty(s)){
+				return Array.Empty<string>();
+			}
+			char[] sepChars = string.IsNullOrEmpty(seps)
+				? AnnotationFileInfo.DefaultValueSeparators.ToCharArray()
+				: seps.ToCharArray();
+			string[] parts = s.Split(sepChars);
+			List<string> result = new List<string>(parts.Length);
+			foreach (string p in parts){
+				string t = p?.Trim();
+				if (string.IsNullOrEmpty(t) || t == "-"){
+					continue;
+				}
+				result.Add(t);
+			}
+			return result.ToArray();
+		}
+
+		private static string[] ExtractCell(string[] cells, int idx, string seps){
+			if (idx < 0 || idx >= cells.Length){
+				return Array.Empty<string>();
+			}
+			return SplitMulti(cells[idx], seps);
+		}
+
+		private static int IndexOf(string[] headers, string name){
+			if (string.IsNullOrEmpty(name) || headers == null){
+				return -1;
+			}
+			for (int i = 0; i < headers.Length; i++){
+				if (string.Equals(headers[i], name, StringComparison.Ordinal)){
+					return i;
+				}
+			}
+			return -1;
+		}
+	}
+}

--- a/MqUtil/Base/MaxQuantParamsWriter.cs
+++ b/MqUtil/Base/MaxQuantParamsWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using MqApi.Util;
+using MqUtil.Annotation;
 using MqUtil.Mol;
 using MqUtil.Util;
 namespace MqUtil.Base {
@@ -38,6 +39,22 @@ namespace MqUtil.Base {
 				return (FastaFileInfo[])x;
 			} catch (Exception) {
 				return new FastaFileInfo[0];
+			}
+		}
+
+		private static AnnotationFileInfo[] GetAnnotationFileInfoArray(InputParameter item, object o) {
+			FieldInfo field = o.GetType().GetField(item.VariableName);
+			object x;
+			if (field != null) {
+				x = field.GetValue(o);
+			} else {
+				PropertyInfo prop = o.GetType().GetProperty(item.VariableName);
+				x = prop.GetValue(o);
+			}
+			try {
+				return (AnnotationFileInfo[])x;
+			} catch (Exception) {
+				return new AnnotationFileInfo[0];
 			}
 		}
 
@@ -115,6 +132,11 @@ namespace MqUtil.Base {
 							WriteFastaFileInfo(writer, baseIndent + indent, val.ElementTypeName, o1);
 						}
 					}
+				} else if (val.IsAnnotationFileInfo) {
+					AnnotationFileInfo[] info = GetAnnotationFileInfoArray(val, obj) ?? new AnnotationFileInfo[0];
+					foreach (AnnotationFileInfo o1 in info) {
+						WriteAnnotationFileInfo(writer, baseIndent + indent, val.ElementTypeName, o1);
+					}
 				} else if (val.IsIsobaricLabelInfo) {
 					IsobaricLabelInfo[] info = GetIsobaricLabelInfoArray(val, obj);
 					if (verboseIsobaricLabels) {
@@ -146,6 +168,14 @@ namespace MqUtil.Base {
 			writer.WriteLine(indent1 + "<" + name + ">");
 			foreach (InputParameter ip in ffi.vals) {
 				WriteElement(writer, indent1 + indent, ip.Name, GetScalar(ip, ffi));
+			}
+			writer.WriteLine(indent1 + "</" + name + ">");
+		}
+
+		private static void WriteAnnotationFileInfo(TextWriter writer, string indent1, string name, AnnotationFileInfo afi) {
+			writer.WriteLine(indent1 + "<" + name + ">");
+			foreach (InputParameter ip in afi.vals) {
+				WriteElement(writer, indent1 + indent, ip.Name, GetScalar(ip, afi));
 			}
 			writer.WriteLine(indent1 + "</" + name + ">");
 		}

--- a/MqUtil/Util/InputParameter.cs
+++ b/MqUtil/Util/InputParameter.cs
@@ -1,4 +1,5 @@
-﻿using MqUtil.Mol;
+﻿using MqUtil.Annotation;
+using MqUtil.Mol;
 namespace MqUtil.Util {
 	public abstract class InputParameter {
 		public string Name { get; }
@@ -14,6 +15,7 @@ namespace MqUtil.Util {
 		public abstract string ElementTypeName { get; }
 		public abstract object DefaultValue { get; }
 		public abstract bool IsFastaFileInfo { get; }
+		public abstract bool IsAnnotationFileInfo { get; }
 		public abstract bool IsIsobaricLabelInfo { get; }
 	}
 
@@ -47,6 +49,9 @@ namespace MqUtil.Util {
 				if (t == typeof(FastaFileInfo)) {
 					return "FastaFileInfo";
 				}
+				if (t == typeof(AnnotationFileInfo)) {
+					return "AnnotationFileInfo";
+				}
 				if (t == typeof(IsobaricLabelInfo)) {
 					return "IsobaricLabelInfo";
 				}
@@ -69,6 +74,15 @@ namespace MqUtil.Util {
 					return Type.GetElementType() == typeof(FastaFileInfo);
 				}
 				return Type == typeof(FastaFileInfo);
+			}
+		}
+
+		public override bool IsAnnotationFileInfo {
+			get {
+				if (IsArray) {
+					return Type.GetElementType() == typeof(AnnotationFileInfo);
+				}
+				return Type == typeof(AnnotationFileInfo);
 			}
 		}
 	}


### PR DESCRIPTION
Adds a self-contained annotation-file ingestion layer — a new AnnotationFileInfo data class plus a tsv AnnotationFileLoader (under MqUtil/Annotation/) and a matching AnnotationFilesParam (under MqApi/Param/) — and extends the existing parameter-XML serializer (InputParameter, MaxQuantParamsWriter) with an IsAnnotationFileInfo branch so the new type round-trips through mqpar.xml like FastaFileInfo